### PR TITLE
Fix such that islandora_object_access_callback and Drupal's user_access ...

### DIFF
--- a/islandora_newspaper.module
+++ b/islandora_newspaper.module
@@ -73,7 +73,12 @@ function islandora_newspaper_manage_newspaper_access_callback($object = NULL) {
     FEDORA_INGEST,
   );
   $is_newspaper = in_array('islandora:newspaperCModel', $object->models);
-  return $is_newspaper && islandora_object_access_callback($manage_actions, $object);
+  $can_access = function($perm) use($object) {
+    return islandora_object_access_callback($perm, $object);
+  };
+  $can_manage = count(array_filter($manage_actions, $can_access));
+  $is_newspaper = in_array('islandora:newspaperCModel', $object->models);
+  return $is_newspaper && $can_manage;
 }
 
 /**


### PR DESCRIPTION
...receives individual strings as opposed to being passed an array when determining the visibility of the manage tab.
