### PR TITLE
Throws an error if issue key does not exist in shared_storage array

### DIFF
--- a/islandora_newspaper.module
+++ b/islandora_newspaper.module
@@ -296,16 +296,18 @@ function islandora_newspaper_islandora_newspaperpagecmodel_islandora_view_object
  */
 function islandora_newspaper_islandora_newspaperpagecmodel_islandora_ingest_steps(array $form_state) {
   $shared_storage = islandora_ingest_form_get_shared_storage($form_state);
-  return array(
-    'islandora_newspaper_upload_pages' => array(
-      'weight' => 10,
-      'type' => 'form',
-      'form_id' => 'islandora_paged_content_upload_page_form',
-      'args' => array($shared_storage['issue']),
-      'module' => 'islandora_paged_content',
-      'file' => 'includes/upload_page.form.inc',
-    ),
-  );
+  if (isset($shared_storage['issue'])) {
+    return array(
+      'islandora_newspaper_upload_pages' => array(
+        'weight' => 10,
+        'type' => 'form',
+        'form_id' => 'islandora_paged_content_upload_page_form',
+        'args' => array($shared_storage['issue']),
+        'module' => 'islandora_paged_content',
+        'file' => 'includes/upload_page.form.inc',
+      ),
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Throws error if newspaperPageCModel type is allowed in a larger collection.

See [ISLANDORA-1189](https://jira.duraspace.org/browse/ISLANDORA-1189)
