### PR TITLE
Address ISLANDORA 1640.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -47,6 +47,18 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
     '#size' => 30,
   );
 
+  $form['islandora_newspaper_issue_list_cache'] = array(
+    '#type' => 'select',
+    '#title' => t('Issue list cache'),
+    '#description' => t("Select how you would like the issue list cache to work. Each newspaper's issue list is cached separately. If you choose \"Clear cache manually\", you can clear all newspapers' cache using \"drush cc all\" or by visiting Administration > Configuration > Development > Performance and submitting the \"Clear all caches\" button."),
+    '#options' => array(
+      'none' => t('Do not cache issue list'),
+      'permanent' => t('Clear cache manually'),
+      'auto' => t('Clear cache on issue ingest/update/removal'),
+    ),
+    '#default_value' => variable_get('islandora_newspaper_issue_list_cache', 'none'),
+  );
+
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_newspaper_issue_viewers', NULL, 'islandora:newspaperIssueCModel');
   $form['issue_viewers'] = $form['viewers'];

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -81,7 +81,7 @@ function islandora_newspaper_get_newspaper($object) {
  */
 function islandora_newspaper_get_issues(AbstractObject $object) {
   $cid = preg_replace('/:/', '_', $object->id);
-  $cid = 'islandora_newspaper_issues_' . $cid;
+  $cid = 'islandora_newspaper_issues:' . $cid;
   if ($cache = cache_get($cid)) {
     $pids = $cache->data['pids'];
     $issues = $cache->data['issues'];

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -150,7 +150,10 @@ EOQ;
 
     $newspaper_issue_data['pids'] = $pids;
     $newspaper_issue_data['issues'] = $issues;
-    cache_set($cid, $newspaper_issue_data);
+    $to_cache = variable_get('islandora_newspaper_issue_list_cache', 'none');
+    if ($to_cache == 'auto' || $to_cache == 'permanent') {
+      cache_set($cid, $newspaper_issue_data);
+    }
     // Make the PIDs the keys.
     return count($pids) ? array_combine($pids, $issues) : array();
   }
@@ -371,4 +374,16 @@ function islandora_newspaper_set_mods_date_issued(AbstractDatastream $datastream
   }
   file_unmanaged_delete($file);
   return $out;
+}
+
+/**
+ * Clears a newspaper's issue list cache.
+ *
+ * @param string $pid
+ *   The PID of the newspaper whose cache is to be cleared.
+ */
+function islandora_newspaper_clear_issue_list_cache($pid) {
+  $cid = preg_replace('/:/', '_', $pid);
+  $cid = 'islandora_newspaper_issues:' . $cid;
+  cache_clear_all($cid, 'cache');
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -80,7 +80,13 @@ function islandora_newspaper_get_newspaper($object) {
  *     - issued: A DateTime object repersenting the date the issue was released.
  */
 function islandora_newspaper_get_issues(AbstractObject $object) {
-  $query = <<<EOQ
+  if ($cache = cache_get('islandora_newspaper_get_issues')) {
+    $pids = $cache->data['pids'];
+    $issues = $cache->data['issues'];
+    return count($pids) ? array_combine($pids, $issues) : array();
+  }
+  else {
+    $query = <<<EOQ
 PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
 PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
 SELECT DISTINCT ?object ?sequence ?label ?issued
@@ -97,50 +103,55 @@ WHERE {
 ORDER BY ?sequence
 EOQ;
 
-  // XXX: Can't really use the fully featured query_filter and query_statements
-  // hook as it will return some things we don't want. Perhaps change the return
-  // structure in the future to specify which module they are coming from? For
-  // now we will just get XACML's directly.
-  $query_optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'view');
-  $query_filters = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_filters');
+    // XXX: Can't really use the fully featured query_filter and
+    // query_statements hook as it will return some things we don't want.
+    // Perhaps change the return structure in the future to specify which
+    // module they are coming from? For now we will just get XACML's directly.
+    $query_optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'view');
+    $query_filters = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_filters');
 
-  $filter_map = function ($filter) {
-    return "FILTER($filter)";
-  };
+    $filter_map = function ($filter) {
+      return "FILTER($filter)";
+    };
 
-  $query = format_string($query, array(
-    '!optionals' => !empty($query_optionals) ? ('OPTIONAL {{' . implode('} UNION {', $query_optionals) . '}}') : '',
-    '!filters' => implode(' ', array_map($filter_map, $query_filters)),
-  ));
+    $query = format_string($query, array(
+      '!optionals' => !empty($query_optionals) ? ('OPTIONAL {{' . implode('} UNION {', $query_optionals) . '}}') : '',
+      '!filters' => implode(' ', array_map($filter_map, $query_filters)),
+    ));
 
-  $results = $object->repository->ri->sparqlQuery($query);
-  // Map the results using a default Datetime for missing issued dates.
-  $map_results = function($o) {
-    try {
-      @$issued = new DateTime($o['issued']['value']);
-    }
-    catch (Exception $e) {
-      // Use the current time as a place holder.
-      $issued = new DateTime();
-      $msg  = 'Failed to get issued date from SPARQL query for @pid';
-      $vars = array('@pid' => $o['object']['value']);
-      watchdog_exception('islandora_newspaper', $e, $msg, $vars, WATCHDOG_ERROR);
-    }
-    return array(
-      'pid' => $o['object']['value'],
-      'label' => $o['label']['value'],
-      'sequence' => $o['sequence']['value'],
-      'issued' => $issued,
-    );
-  };
-  $issues = array_map($map_results, $results);
-  // Grab the PIDs...
-  $get_pid = function($o) {
-    return $o['pid'];
-  };
-  $pids = array_map($get_pid, $issues);
-  // Make the PIDs the keys.
-  return count($pids) ? array_combine($pids, $issues) : array();
+    $results = $object->repository->ri->sparqlQuery($query);
+    // Map the results using a default Datetime for missing issued dates.
+    $map_results = function($o) {
+      try {
+        @$issued = new DateTime($o['issued']['value']);
+      }
+      catch (Exception $e) {
+        // Use the current time as a place holder.
+        $issued = new DateTime();
+        $msg  = 'Failed to get issued date from SPARQL query for @pid';
+        $vars = array('@pid' => $o['object']['value']);
+        watchdog_exception('islandora_newspaper', $e, $msg, $vars, WATCHDOG_ERROR);
+      }
+      return array(
+        'pid' => $o['object']['value'],
+        'label' => $o['label']['value'],
+        'sequence' => $o['sequence']['value'],
+        'issued' => $issued,
+      );
+    };
+    $issues = array_map($map_results, $results);
+    // Grab the PIDs...
+    $get_pid = function($o) {
+      return $o['pid'];
+    };
+    $pids = array_map($get_pid, $issues);
+
+    $newspaper_issue_data['pids'] = $pids;
+    $newspaper_issue_data['issues'] = $issues;
+    cache_set('islandora_newspaper_get_issues', $newspaper_issue_data);
+    // Make the PIDs the keys.
+    return count($pids) ? array_combine($pids, $issues) : array();
+  }
 }
 
 /**

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -80,7 +80,9 @@ function islandora_newspaper_get_newspaper($object) {
  *     - issued: A DateTime object repersenting the date the issue was released.
  */
 function islandora_newspaper_get_issues(AbstractObject $object) {
-  if ($cache = cache_get('islandora_newspaper_get_issues')) {
+  $cid = preg_replace('/:/', '_', $object->id);
+  $cid = 'islandora_newspaper_issues_' . $cid;
+  if ($cache = cache_get($cid)) {
     $pids = $cache->data['pids'];
     $issues = $cache->data['issues'];
     return count($pids) ? array_combine($pids, $issues) : array();
@@ -148,7 +150,7 @@ EOQ;
 
     $newspaper_issue_data['pids'] = $pids;
     $newspaper_issue_data['issues'] = $issues;
-    cache_set('islandora_newspaper_get_issues', $newspaper_issue_data);
+    cache_set($cid, $newspaper_issue_data);
     // Make the PIDs the keys.
     return count($pids) ? array_combine($pids, $issues) : array();
   }

--- a/islandora_newspaper.install
+++ b/islandora_newspaper.install
@@ -21,6 +21,9 @@ function islandora_newspaper_install() {
 function islandora_newspaper_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_newspaper', 'uninstall');
-  $variables = array('islandora_newspaper_page_viewers');
+  $variables = array(
+    'islandora_newspaper_page_viewers',
+    'islandora_newspaper_issue_list_cache',
+  );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_newspaper.module
+++ b/islandora_newspaper.module
@@ -350,7 +350,8 @@ function islandora_newspaper_islandora_newspaperIssueCModel_islandora_ingest_ste
 /**
  * Implements hook_cmodel_dsid_islandora_datastream_ingested().
  *
- * This updates the RELS-EXT such that the date issued matches the mods.
+ * This updates the RELS-EXT such that the date issued matches the mods
+ * and clears the issue list cache.
  */
 function islandora_newspaper_islandora_newspaperissuecmodel_mods_islandora_datastream_ingested(AbstractObject $object, AbstractDatastream $datastream) {
   module_load_include('inc', 'islandora_newspaper', 'includes/utilities');
@@ -358,18 +359,43 @@ function islandora_newspaper_islandora_newspaperissuecmodel_mods_islandora_datas
   if ($date_issued) {
     islandora_newspaper_set_date_issued($object, $date_issued);
   }
+  if (variable_get('islandora_newspaper_issue_list_cache', 'none') == 'auto') {
+    if ($newspaper_pid = islandora_newspaper_get_newspaper($object)) {
+      islandora_newspaper_clear_issue_list_cache($newspaper_pid);
+    }
+  }
 }
 
 /**
  * Implements hook_cmodel_dsid_islandora_datastream_ingested().
  *
- * This updates the RELS-EXT such that the date issued matches the mods.
+ * This updates the RELS-EXT such that the date issued matches the mods
+ * and clears the issue list cache.
  */
 function islandora_newspaper_islandora_newspaperissuecmodel_mods_islandora_datastream_modified(AbstractObject $object, AbstractDatastream $datastream) {
   module_load_include('inc', 'islandora_newspaper', 'includes/utilities');
   $date_issued = islandora_newspaper_get_date_issued_from_mods($datastream);
   if ($date_issued) {
     islandora_newspaper_set_date_issued($object, $date_issued);
+  }
+  if (variable_get('islandora_newspaper_issue_list_cache', 'none') == 'auto') {
+    if ($newspaper_pid = islandora_newspaper_get_newspaper($object)) {
+      islandora_newspaper_clear_issue_list_cache($newspaper_pid);
+    }
+  }
+}
+
+/**
+ * Implements hook_cmodel_pid_islandora_datastream_purged().
+ *
+ * This clears the issue list cache.
+ */
+function islandora_newspaper_islandora_newspaperissuecmodel_mods_islandora_datastream_purged(AbstractObject $object, AbstractDatastream $datastream) {
+  module_load_include('inc', 'islandora_newspaper', 'includes/utilities');
+  if (variable_get('islandora_newspaper_issue_list_cache', 'none') == 'auto') {
+    if ($newspaper_pid = islandora_newspaper_get_newspaper($object)) {
+      islandora_newspaper_clear_issue_list_cache($newspaper_pid);
+    }
   }
 }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1640
# What does this Pull Request do?

Uses Drupal's Cache API to cache the list of newspaper issues.
# What's new?

islandora_newspaper_get_issues() now checks to see if a cached version of the issue list data exists; if it doesn't, generates the data as previously and also caches it; if cached version does exist, returns it and skips regenerating it. Provide three options in the Newspaper SP's admin settings:
- Do not cache issue list [default setting, will not impact sites that are currently running the Newspaper SP]
- Clear cache manually [cache is permanent but can be cleared using drush cc all or standard 'Clear all caches' button in Drupal admin settings]
- Clear cache on issue ingest/update/removal [will clear cache on issue ingest or purging, and if any of the issue-level MODS datastreams are updated]
# How should this be tested?
- Check out this branch.
- In the Newspaper SP admin options' new "Issue list cache" select widget, choose "Clear cache on issue ingest/update/removal". Save the admin options form.
- Visit the issue navigator for a large newspaper. This will populate the cache.
- To confirm that the issue cache is populated, in the mysql client run `select cid,created from cache;`. You should see the cache ID for the newspaper you just visited and when it was populated.
- In the MODS datastream for an issue of that newspaper, edit the data issued value.
- Rerun the mysql query. The 'created' value should be different from its original (pre-MODS edit).
# Additional Notes:

Changes in this PR will need updates to documentation. Updates to admin settings are optional.
# Interested parties

@whikloj @ppound and other users who have large newspapers in Islandora.
