### PR TITLE
7.x-ISLANDORA-1653 (Issue list from Solr)

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -20,6 +20,10 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
   $get_default_value = function($name, $default) use(&$form_state) {
     return isset($form_state['values'][$name]) ? $form_state['values'][$name] : variable_get($name, $default);
   };
+
+  $solr_enabled = module_exists('islandora_solr');
+  $solr_message = ($solr_enabled ? "" : "Islandora Solr is required.");
+
   $form = array(
     'local_derivative_settings' => array(
       '#type' => 'fieldset',
@@ -45,8 +49,10 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
     'islandora_newspaper_use_solr' => array(
       '#type' => 'checkbox',
       '#title' => t('Use Solr to get issues and pages'),
-      '#description' => t('Replaces newspapers resource index queries with Solr ones.'),
-      '#default_value' => variable_get('islandora_newspaper_use_solr', FALSE),
+      '#disabled' => (!$solr_enabled),
+      '#description' => t('Replaces newspapers resource index queries with Solr ones. @msg',
+        array('@msg' => $solr_message)),
+      '#default_value' => (variable_get('islandora_newspaper_use_solr', FALSE) && $solr_enabled),
       '#return_value' => TRUE,
     ),
     'islandora_newspapers_solr_options' => array(

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -39,9 +39,6 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
     ),
   );
 
-
-  
-  
   $form['islandora_newspaper_solr_wrapper'] = array(
     '#type' => 'fieldset',
     '#title' => t('Solr replacements'),
@@ -77,7 +74,7 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
           'required' => array(
             ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
           ),
-        )
+        ),
       ),
       'islandora_newspaper_pageof_solr_field' => array(
         '#type' => 'textfield',
@@ -90,7 +87,7 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
           'required' => array(
             ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
           ),
-        )
+        ),
       ),
       'islandora_newspaper_sequence_number_solr_field' => array(
         '#type' => 'textfield',
@@ -103,11 +100,10 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
           'required' => array(
             ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
           ),
-        )
+        ),
       ),
     ),
   );
-
 
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_newspaper_issue_viewers', NULL, 'islandora:newspaperIssueCModel');

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -49,18 +49,24 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
       '#default_value' => variable_get('islandora_newspaper_use_solr', FALSE),
       '#return_value' => TRUE,
     ),
-    'islandora_newspaper_parent_issue_solr_field' => array(
-      '#type' => 'textfield',
-      '#title' => t('Parent Solr Field'),
-      '#description' => t("Solr field containing the parent issue's PID."),
-      '#default_value' => variable_get('islandora_newspaper_parent_issue_solr_field', 'RELS_EXT_isMemberOf_uri_ms'),
-      '#size' => 30,
-    ),
     'islandora_newspapers_solr_options' => array(
       '#type' => 'container',
       '#states' => array(
         'visible' => array(
           ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
+        ),
+      ),
+      'islandora_newspaper_parent_issue_solr_field' => array(
+        '#type' => 'textfield',
+        '#title' => t('Parent Solr Field'),
+        '#description' => t("Solr field containing the parent issue's PID."),
+        '#default_value' => variable_get('islandora_newspaper_parent_issue_solr_field', 'RELS_EXT_isMemberOf_uri_ms'),
+        '#size' => 100,
+        '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+        '#states' => array(
+          'required' => array(
+            ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
+          ),
         ),
       ),
       'islandora_newspaper_date_issued_solr_field' => array(
@@ -69,19 +75,6 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
         '#description' => t('Solr field that contains the date issued of the newspaper.'),
         '#size' => 100,
         '#default_value' => variable_get('islandora_newspaper_date_issued_solr_field', ''),
-        '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
-        '#states' => array(
-          'required' => array(
-            ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
-          ),
-        ),
-      ),
-      'islandora_newspaper_pageof_solr_field' => array(
-        '#type' => 'textfield',
-        '#title' => t('Page Of field'),
-        '#description' => t('Solr field that contains the isPageOf reference of a newspaper page.'),
-        '#size' => 100,
-        '#default_value' => variable_get('islandora_newspaper_pageof_solr_field', 'RELS_EXT_isPageOf_uri_ms'),
         '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
         '#states' => array(
           'required' => array(
@@ -128,8 +121,8 @@ function islandora_newspaper_admin_settings_form_validate(array $form, array &$f
     if (empty($form_state['values']['islandora_newspaper_sequence_number_solr_field'])) {
       $error['islandora_newspaper_sequence_number_solr_field'] = t('Sequence number field cannot be blank');
     }
-    if (empty($form_state['values']['islandora_newspaper_pageof_solr_field'])) {
-      $error['islandora_newspaper_pageof_solr_field'] = t('PageOf field cannot be blank');
+    if (empty($form_state['values']['islandora_newspaper_parent_issue_solr_field'])) {
+      $error['islandora_newspaper_parent_issue_solr_field'] = t('Parent Solr field cannot be blank');
     }
     if (empty($form_state['values']['islandora_newspaper_date_issued_solr_field'])) {
       $error['islandora_newspaper_date_issued_solr_field'] = t('Date issued field cannot be blank');

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -39,13 +39,75 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
     ),
   );
 
-  $form['islandora_newspaper_parent_issue_solr_field'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Parent Solr Field'),
-    '#description' => t("Solr field containing the parent issue's PID."),
-    '#default_value' => variable_get('islandora_newspaper_parent_issue_solr_field', 'RELS_EXT_isMemberOf_uri_ms'),
-    '#size' => 30,
+
+  
+  
+  $form['islandora_newspaper_solr_wrapper'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Solr replacements'),
+    'islandora_newspaper_use_solr' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Use Solr to get issues and pages'),
+      '#description' => t('Replaces newspapers resource index queries with Solr ones.'),
+      '#default_value' => variable_get('islandora_newspaper_use_solr', FALSE),
+      '#return_value' => TRUE,
+    ),
+    'islandora_newspaper_parent_issue_solr_field' => array(
+      '#type' => 'textfield',
+      '#title' => t('Parent Solr Field'),
+      '#description' => t("Solr field containing the parent issue's PID."),
+      '#default_value' => variable_get('islandora_newspaper_parent_issue_solr_field', 'RELS_EXT_isMemberOf_uri_ms'),
+      '#size' => 30,
+    ),
+    'islandora_newspapers_solr_options' => array(
+      '#type' => 'container',
+      '#states' => array(
+        'visible' => array(
+          ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
+        ),
+      ),
+      'islandora_newspaper_date_issued_solr_field' => array(
+        '#type' => 'textfield',
+        '#title' => t('Issued date field'),
+        '#description' => t('Solr field that contains the date issued of the newspaper.'),
+        '#size' => 100,
+        '#default_value' => variable_get('islandora_newspaper_date_issued_solr_field', ''),
+        '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+        '#states' => array(
+          'required' => array(
+            ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
+          ),
+        )
+      ),
+      'islandora_newspaper_pageof_solr_field' => array(
+        '#type' => 'textfield',
+        '#title' => t('Page Of field'),
+        '#description' => t('Solr field that contains the isPageOf reference of a newspaper page.'),
+        '#size' => 100,
+        '#default_value' => variable_get('islandora_newspaper_pageof_solr_field', 'RELS_EXT_isPageOf_uri_ms'),
+        '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+        '#states' => array(
+          'required' => array(
+            ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
+          ),
+        )
+      ),
+      'islandora_newspaper_sequence_number_solr_field' => array(
+        '#type' => 'textfield',
+        '#title' => t('Sequence number field'),
+        '#description' => t('Solr field that contains the sequence number of the newspaper.'),
+        '#size' => 100,
+        '#default_value' => variable_get('islandora_newspaper_sequence_number_solr_field', 'RELS_EXT_isSequenceNumber_literal_ms'),
+        '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+        '#states' => array(
+          'required' => array(
+            ':input[name="islandora_newspaper_use_solr"]' => array('checked' => TRUE),
+          ),
+        )
+      ),
+    ),
   );
+
 
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_newspaper_issue_viewers', NULL, 'islandora:newspaperIssueCModel');
@@ -57,6 +119,38 @@ function islandora_newspaper_admin_settings_form(array $form, array &$form_state
   $form['page_viewers']['#title'] = t('Page Viewers');
   unset($form['viewers']);
   return system_settings_form($form);
+}
+
+/**
+ * Implements hook_form_validate().
+ *
+ * Custom validation to handle required fields if you choose to use Solr.
+ */
+function islandora_newspaper_admin_settings_form_validate(array $form, array &$form_state) {
+  $error = array();
+  if ($form_state['values']['islandora_newspaper_use_solr']) {
+    if (empty($form_state['values']['islandora_newspaper_sequence_number_solr_field'])) {
+      $error['islandora_newspaper_sequence_number_solr_field'] = t('Sequence number field cannot be blank');
+    }
+    if (empty($form_state['values']['islandora_newspaper_pageof_solr_field'])) {
+      $error['islandora_newspaper_pageof_solr_field'] = t('PageOf field cannot be blank');
+    }
+    if (empty($form_state['values']['islandora_newspaper_date_issued_solr_field'])) {
+      $error['islandora_newspaper_date_issued_solr_field'] = t('Date issued field cannot be blank');
+    }
+  }
+  if (count($error) > 0) {
+    foreach ($error as $field => $message) {
+      form_set_error($field, $message);
+    }
+  }
+}
+
+/**
+ * Implements hook_form_submit().
+ */
+function islandora_newspaper_admin_settings_form_submit(array $form, array &$form_state) {
+  system_settings_form_submit($form, $form_state);
 }
 
 /**

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -54,7 +54,7 @@ function islandora_newspaper_get_current_sequence($object) {
  *   no such membership, returns FALSE.
  */
 function islandora_newspaper_get_newspaper($object) {
-  if (variable_get('islandora_newspaper_use_solr', FALSE)) {
+  if (variable_get('islandora_newspaper_use_solr', FALSE) && module_exists('islandora_solr')) {
     return islandora_newspaper_get_newspaper_solr($object);
   }
   else {
@@ -142,7 +142,7 @@ function islandora_newspaper_get_newspaper_ri($object) {
  *     - issued: A DateTime object repersenting the date the issue was released.
  */
 function islandora_newspaper_get_issues(AbstractObject $object) {
-  if (variable_get('islandora_newspaper_use_solr', FALSE)) {
+  if (variable_get('islandora_newspaper_use_solr', FALSE) && module_exists('islandora_solr')) {
     return islandora_newspaper_get_issues_solr($object);
   }
   else {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -181,9 +181,13 @@ function islandora_newspaper_get_issues_solr(AbstractObject $object) {
     $parent_field,
     $sequence_field,
   );
+
+  $issue_count = islandora_newspaper_count_issues_solr($object);
+
+  // TODO: Probably do multiple queries in a loop if over a threshold size.
   $solr_params = array(
-    'rows' => 30000,
-    'limit' => 30000,
+    'rows' => $issue_count,
+    'limit' => $issue_count,
     'fl' => implode(', ', $fields),
     'hl' => 'false',
     'facet' => 'false',
@@ -543,4 +547,43 @@ function islandora_newspaper_set_mods_date_issued(AbstractDatastream $datastream
   }
   file_unmanaged_delete($file);
   return $out;
+}
+
+/**
+ * Return a count of all the issues of the given newspaper.
+ *
+ * @param AbstractObject $object
+ *   The newspaper object.
+ *
+ * @return int
+ *   The count of issues.
+ */
+function islandora_newspaper_count_issues_solr(AbstractObject $object) {
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
+  $parent_field = variable_get('islandora_newspaper_parent_issue_solr_field', 'RELS_EXT_isMemberOf_uri_ms');
+
+  $solr_build = new IslandoraSolrQueryProcessor();
+  $pid = islandora_solr_lesser_escape($object->id);
+  $ns_pid = islandora_solr_lesser_escape("info:fedora/{$object->id}");
+
+  $solr_query = "($parent_field:{$pid}+OR+$parent_field:{$ns_pid})+AND+RELS_EXT_hasModel_uri_ms:\"info:fedora/islandora:newspaperIssueCModel\"";
+
+  $solr_params = array(
+    'rows' => 0,
+    'facet' => 'false',
+    'hl' => 'false',
+  );
+
+  $solr_build->buildQuery($solr_query, $solr_params);
+  $solr_build->solrParams = array_replace_recursive($solr_build->solrParams, $solr_params);
+
+  try {
+    $solr_build->executeQuery();
+    $results = $solr_build->islandoraSolrResult['response']['numFound'];
+  }
+  catch (Exception $e) {
+    $results = 0;
+    drupal_set_message(t('Error searching Solr index: !e', array('!e' => $e->getMessage())), 'error', FALSE);
+  }
+  return $results;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -76,7 +76,7 @@ function islandora_newspaper_get_newspaper_solr($object) {
   module_load_include('inc', 'islandora_solr', 'includes/utilities');
   $solr_build = new IslandoraSolrQueryProcessor();
   $parent_field = variable_get('islandora_newspaper_parent_issue_solr_field', 'RELS_EXT_isMemberOf_uri_ms');
-  $solr_param = array(
+  $solr_params = array(
     'rows' => 20,
     'limit' => 20,
     'fl' => $parent_field,
@@ -86,9 +86,9 @@ function islandora_newspaper_get_newspaper_solr($object) {
   );
   $pid = islandora_solr_lesser_escape($object->id);
   $solr_query = "PID:{$pid}";
-  $solr_build->buildQuery($query, $solr_params);
+  $solr_build->buildQuery($solr_query, $solr_params);
   $solr_build->solrParams = array_replace_recursive($solr_build->solrParams, $solr_params);
-  
+
   try {
     $solr_build->executeQuery(FALSE);
     $results = (array) $solr_build->islandoraSolrResult['response']['objects'];
@@ -97,7 +97,7 @@ function islandora_newspaper_get_newspaper_solr($object) {
     $results = array();
     drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error', FALSE);
   }
-  
+
   $rel = reset($results);
   if ($rel) {
     return $rel['PID'];
@@ -106,7 +106,7 @@ function islandora_newspaper_get_newspaper_solr($object) {
 }
 
 /**
- * Returns the collection object of a given issue object from the resource index.
+ * Returns the collection object of an issue object from the resource index.
  *
  * @param object $object
  *   Newspaper issue object.
@@ -114,7 +114,7 @@ function islandora_newspaper_get_newspaper_solr($object) {
  * @return string|bool
  *   Returns the PID of the newspaper of which $object is a member. If there is
  *   no such membership, returns FALSE.
- */  
+ */
 function islandora_newspaper_get_newspaper_ri($object) {
   $rels = $object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOf');
   $rel = reset($rels);
@@ -170,68 +170,70 @@ function islandora_newspaper_get_issues(AbstractObject $object) {
 function islandora_newspaper_get_issues_solr(AbstractObject $object) {
   module_load_include('inc', 'islandora_solr', 'includes/utilities');
   $solr_build = new IslandoraSolrQueryProcessor();
-  
+
   $parent_field = variable_get('islandora_newspaper_parent_issue_solr_field', 'RELS_EXT_isMemberOf_uri_ms');
-  $date_field = variable_get('islandora_newspaper_date_issued_solr_field', '');
+  $date_field = variable_get('islandora_newspaper_date_issued_solr_field', 'RELS_EXT_dateIssued_literal_ms');
   $sequence_field = variable_get('islandora_newspaper_sequence_number_solr_field', 'RELS_EXT_isSequenceNumber_literal_ms');
-  $solr_param = array(
+  $fields = array(
+    'PID',
+    'fgs_label_ms',
+    $date_field,
+    $parent_field,
+    $sequence_field,
+  );
+  $solr_params = array(
     'rows' => 30000,
     'limit' => 30000,
-    'fl' => array(
-      'PID',
-      'fgs_label_s',
-      $date_field,
-      $parent_field,
-      $sequence_field,
-    ),
+    'fl' => implode(', ', $fields),
     'hl' => 'false',
     'facet' => 'false',
   );
   $pid = islandora_solr_lesser_escape($object->id);
   $ns_pid = islandora_solr_lesser_escape("info:fedora/{$object->id}");
-  
-  $solr_query = "($parent_field:{$pid}+OR+$parent_field:{$ns_pid})+AND+RELS_EXT_hasModel_uri_ms:\"info:fedora/islandora:newspaperIssueCModel\")";
 
+  $solr_query = "($parent_field:{$pid}+OR+$parent_field:{$ns_pid})+AND+RELS_EXT_hasModel_uri_ms:\"info:fedora/islandora:newspaperIssueCModel\"";
 
-  $solr_build->buildQuery($query, $solr_params);
+  $solr_build->buildQuery($solr_query, $solr_params);
   $solr_build->solrParams = array_replace_recursive($solr_build->solrParams, $solr_params);
-  
+
   try {
     $solr_build->executeQuery(FALSE);
     $results = (array) $solr_build->islandoraSolrResult['response']['objects'];
   }
   catch (Exception $e) {
     $results = array();
-    drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error', FALSE);
+    drupal_set_message(t('Error searching Solr index: !e', array('!e' => $e->getMessage())), 'error', FALSE);
   }
-  
+
   // Map the results using a default Datetime for missing issued dates.
   $map_results = function($o) use ($date_field, $sequence_field) {
     try {
-      @$issued = new DateTime($o[$date_field]);
+      @$issued = new DateTime($o['solr_doc'][$date_field]);
     }
     catch (Exception $e) {
       // Use the current time as a place holder.
       $issued = new DateTime();
-      $msg  = 'Failed to get issued date from SPARQL query for @pid';
+      $msg  = 'Failed to get issued date from SOLR query for @pid';
       $vars = array('@pid' => $o['PID']);
       watchdog_exception('islandora_newspaper', $e, $msg, $vars, WATCHDOG_ERROR);
     }
-    if (isset($o[$sequence_field])) {
-      if (is_array($o[$sequence_field])) {
-        $o[$sequence_field] = reset($o[$sequence_field]);
-        if ($o[$sequence_field] === FALSE) {
-          $o[$sequence_field] = 0;
+    $get_value = function($field, $default = "") use ($o) {
+      if (isset($o['solr_doc'][$field])) {
+        if (is_array($o['solr_doc'][$field]) && isset($o['solr_doc'][$field][0])) {
+          return $o['solr_doc'][$field][0];
+        }
+        else {
+          return $o['solr_doc'][$field];
         }
       }
-    }
-    else {
-      $o['RELS_EXT_isSequenceNumber_literal_ms'] = 0;
-    }
+      else {
+        return $default;
+      }
+    };
     return array(
-      'pid' => $o['PID'],
-      'label' => $o['fgs_label_s'],
-      'sequence' => $o[$sequence_field],
+      'pid' => $get_value('PID'),
+      'label' => $get_value('fgs_label_ms'),
+      'sequence' => $get_value($sequence_field, 0),
       'issued' => $issued,
     );
   };

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -54,6 +54,68 @@ function islandora_newspaper_get_current_sequence($object) {
  *   no such membership, returns FALSE.
  */
 function islandora_newspaper_get_newspaper($object) {
+  if (variable_get('islandora_newspaper_use_solr', FALSE)) {
+    return islandora_newspaper_get_newspaper_solr($object);
+  }
+  else {
+    return islandora_newspaper_get_newspaper_ri($object);
+  }
+}
+
+/**
+ * Returns the collection object of a given issue object from the Solr index.
+ *
+ * @param object $object
+ *   Newspaper issue object.
+ *
+ * @return string|bool
+ *   Returns the PID of the newspaper of which $object is a member. If there is
+ *   no such membership, returns FALSE.
+ */
+function islandora_newspaper_get_newspaper_solr($object) {
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
+  $solr_build = new IslandoraSolrQueryProcessor();
+  $parent_field = variable_get('islandora_newspaper_parent_issue_solr_field', 'RELS_EXT_isMemberOf_uri_ms');
+  $solr_param = array(
+    'rows' => 20,
+    'limit' => 20,
+    'fl' => $parent_field,
+    'hl' => 'false',
+    'facet' => 'false',
+    'fq' => array('RELS_EXT_hasModel_uri_ms:"info:fedora/islandora:newspaperCModel"'),
+  );
+  $pid = islandora_solr_lesser_escape($object->id);
+  $solr_query = "PID:{$pid}";
+  $solr_build->buildQuery($query, $solr_params);
+  $solr_build->solrParams = array_replace_recursive($solr_build->solrParams, $solr_params);
+  
+  try {
+    $solr_build->executeQuery(FALSE);
+    $results = (array) $solr_build->islandoraSolrResult['response']['objects'];
+  }
+  catch (Exception $e) {
+    $results = array();
+    drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error', FALSE);
+  }
+  
+  $rel = reset($results);
+  if ($rel) {
+    return $rel['PID'];
+  }
+  return FALSE;
+}
+
+/**
+ * Returns the collection object of a given issue object from the resource index.
+ *
+ * @param object $object
+ *   Newspaper issue object.
+ *
+ * @return string|bool
+ *   Returns the PID of the newspaper of which $object is a member. If there is
+ *   no such membership, returns FALSE.
+ */  
+function islandora_newspaper_get_newspaper_ri($object) {
   $rels = $object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOf');
   $rel = reset($rels);
   if ($rel) {
@@ -80,6 +142,127 @@ function islandora_newspaper_get_newspaper($object) {
  *     - issued: A DateTime object repersenting the date the issue was released.
  */
 function islandora_newspaper_get_issues(AbstractObject $object) {
+  if (variable_get('islandora_newspaper_use_solr', FALSE)) {
+    return islandora_newspaper_get_issues_solr($object);
+  }
+  else {
+    return islandora_newspaper_get_issues_ri($object);
+  }
+}
+
+/**
+ * Gets all the issues that the given newspaper owns from the Solr index.
+ *
+ * The results are ordered by their RELS-EXT dateIssued property.
+ * Older to newer.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing a Fedora object.
+ *
+ * @return array
+ *   An associative array in the form of:
+ *   - pid: The unique persistent identifier for the issue.
+ *     - pid: The unique persistent identifier for the issue.
+ *     - label: A descriptive label for the issue.
+ *     - sequence: The sequence number of the issue, starts at 1.
+ *     - issued: A DateTime object repersenting the date the issue was released.
+ */
+function islandora_newspaper_get_issues_solr(AbstractObject $object) {
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
+  $solr_build = new IslandoraSolrQueryProcessor();
+  
+  $parent_field = variable_get('islandora_newspaper_parent_issue_solr_field', 'RELS_EXT_isMemberOf_uri_ms');
+  $date_field = variable_get('islandora_newspaper_date_issued_solr_field', '');
+  $sequence_field = variable_get('islandora_newspaper_sequence_number_solr_field', 'RELS_EXT_isSequenceNumber_literal_ms');
+  $solr_param = array(
+    'rows' => 30000,
+    'limit' => 30000,
+    'fl' => array(
+      'PID',
+      'fgs_label_s',
+      $date_field,
+      $parent_field,
+      $sequence_field,
+    ),
+    'hl' => 'false',
+    'facet' => 'false',
+  );
+  $pid = islandora_solr_lesser_escape($object->id);
+  $ns_pid = islandora_solr_lesser_escape("info:fedora/{$object->id}");
+  
+  $solr_query = "($parent_field:{$pid}+OR+$parent_field:{$ns_pid})+AND+RELS_EXT_hasModel_uri_ms:\"info:fedora/islandora:newspaperIssueCModel\")";
+
+
+  $solr_build->buildQuery($query, $solr_params);
+  $solr_build->solrParams = array_replace_recursive($solr_build->solrParams, $solr_params);
+  
+  try {
+    $solr_build->executeQuery(FALSE);
+    $results = (array) $solr_build->islandoraSolrResult['response']['objects'];
+  }
+  catch (Exception $e) {
+    $results = array();
+    drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error', FALSE);
+  }
+  
+  // Map the results using a default Datetime for missing issued dates.
+  $map_results = function($o) use ($date_field, $sequence_field) {
+    try {
+      @$issued = new DateTime($o[$date_field]);
+    }
+    catch (Exception $e) {
+      // Use the current time as a place holder.
+      $issued = new DateTime();
+      $msg  = 'Failed to get issued date from SPARQL query for @pid';
+      $vars = array('@pid' => $o['PID']);
+      watchdog_exception('islandora_newspaper', $e, $msg, $vars, WATCHDOG_ERROR);
+    }
+    if (isset($o[$sequence_field])) {
+      if (is_array($o[$sequence_field])) {
+        $o[$sequence_field] = reset($o[$sequence_field]);
+        if ($o[$sequence_field] === FALSE) {
+          $o[$sequence_field] = 0;
+        }
+      }
+    }
+    else {
+      $o['RELS_EXT_isSequenceNumber_literal_ms'] = 0;
+    }
+    return array(
+      'pid' => $o['PID'],
+      'label' => $o['fgs_label_s'],
+      'sequence' => $o[$sequence_field],
+      'issued' => $issued,
+    );
+  };
+  $issues = array_map($map_results, $results);
+  // Grab the PIDs...
+  $get_pid = function($o) {
+    return $o['pid'];
+  };
+  $pids = array_map($get_pid, $issues);
+  // Make the PIDs the keys.
+  return count($pids) ? array_combine($pids, $issues) : array();
+}
+
+/**
+ * Gets all the issues that the given newspaper owns.
+ *
+ * The results are ordered by their RELS-EXT dateIssued property.
+ * Older to newer.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing a Fedora object.
+ *
+ * @return array
+ *   An associative array in the form of:
+ *   - pid: The unique persistent identifier for the issue.
+ *     - pid: The unique persistent identifier for the issue.
+ *     - label: A descriptive label for the issue.
+ *     - sequence: The sequence number of the issue, starts at 1.
+ *     - issued: A DateTime object repersenting the date the issue was released.
+ */
+function islandora_newspaper_get_issues_ri(AbstractObject $object) {
   $query = <<<EOQ
 PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
 PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>

--- a/islandora_newspaper.install
+++ b/islandora_newspaper.install
@@ -21,6 +21,14 @@ function islandora_newspaper_install() {
 function islandora_newspaper_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_newspaper', 'uninstall');
-  $variables = array('islandora_newspaper_page_viewers');
+  $variables = array(
+    'islandora_newspaper_page_viewers',
+    'islandora_newspaper_parent_issue_solr_field',
+    'islandora_newspaper_use_solr',
+    'islandora_newspaper_date_issued_solr_field',
+    'islandora_newspaper_ingest_derivatives',
+    'islandora_newspaper_sequence_number_solr_field',
+    'islandora_newspaper_pageof_solr_field',
+  );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_newspaper.install
+++ b/islandora_newspaper.install
@@ -28,7 +28,6 @@ function islandora_newspaper_uninstall() {
     'islandora_newspaper_date_issued_solr_field',
     'islandora_newspaper_ingest_derivatives',
     'islandora_newspaper_sequence_number_solr_field',
-    'islandora_newspaper_pageof_solr_field',
   );
   array_walk($variables, 'variable_del');
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1653
# What does this Pull Request do?

The issue listing for newspapers are generated by a query of the resource index, which can be slow. This PR adds options to have the issue list and reverse newspaper lookup done from Solr instead.
# What's new?

Adds variable entries for Solr fields:
- islandora_newspaper_use_solr
- islandora_newspaper_date_issued_solr_field
- islandora_newspaper_sequence_number_solr_field

If islandora_newspaper_use_solr is TRUE, the query for issues is sent to Solr using the other two fields (along with a pre-existing _islandora_newspaper_parent_issue_solr_field_) otherwise it is returned to the resource index.

Also the reverse action of querying for the newspaper object of a specific issue will use Solr instead of the resource index.
# How should this be tested?
- Load a newspaper display page with (preferably) quite a few issues.
- Enable the Solr replace from the Newspaper Solution Pack admin page filling in the required field for your Solr schema.
- Re-load the newspaper page, it should (hopefully) be faster but otherwise exactly the same.
# Additional Notes:

Any additional information that you think would be helpful when reviewing this PR.

Example:
- Does this change require documentation to be updated? 
  **Perhaps some new configuration instructions.**
- Does this change add any new dependencies? 
  **No, if the Islandora Solr module is not enabled you cannot enable this functionality.**
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
  **No**
- Could this change impact execution of existing code? 
  **No**
# Interested parties

@mjordan @ppound for the love of newspapers.
