### PR TITLE
Fixes wrong Tesseract  Download Location

### DIFF
--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -1,24 +1,42 @@
+#!/bin/sh
 apt-get update
 apt-get install build-essential checkinstall 
-mkdir ~/tesseract
-cd ~/tesseract
-wget http://www.leptonica.org/source/leptonica-1.69.tar.gz
-tar xf leptonica-1.69.tar.gz && rm -rf leptonica-1.69.tar.gz
-cd leptonica-1.69
-./configure
-make && checkinstall --pkgname=libleptonica --pkgversion="1.69" --backup=no --deldoc=yes --fstrans=no --default
-cd ~/tesseract
-wget https://tesseract-ocr.googlecode.com/files/tesseract-ocr-3.02.02.tar.gz
-tar xf tesseract-ocr-3.02.02.tar.gz && rm -rf tesseract-ocr-3.02.02.tar.gz
-cd tesseract-ocr
-./autogen.sh
-./configure
-make && checkinstall --pkgname=tesseract-ocr --pkgversion="3.02.02" --backup=no --deldoc=yes --fstrans=no --default && ldconfig
-mkdir ~/tesseract/langs
-cd ~/tesseract/langs
-wget https://tesseract-ocr.googlecode.com/files/tesseract-ocr-3.02.eng.tar.gz
-echo "Extracting language files"
-for i in *.tar.gz; do echo -e "\nworking on $i\n"; tar xvzf $i ; done
-cp tesseract-ocr/tessdata/* /usr/local/share/tessdata/
-echo -e "\ntesseract output:"
-tesseract --version && tesseract --list-langs && cd ~ && rm -rf ~/tesseract
+# Go for Ubuntu's packages first
+FROMSOURCE=0
+echo "Installing Tesseract OCR using Trusty Ubuntu Packages"
+apt-get -y install tesseract-ocr tesseract-ocr-eng
+# Check if install worked
+$(command -v tesseract --version > /dev/null 2>&1)
+if [ "$?" -eq "1" ]; then
+  printf "\n"
+  echo "Tesseract could not be installed via apt-get"
+  printf "\n"
+  echo "Will try from source now"
+  FROMSOURCE=1
+fi
+
+if [ "$FROMSOURCE" -eq 1 ]; then
+  mkdir ~/tesseract
+  cd ~/tesseract
+  wget http://www.leptonica.org/source/leptonica-1.69.tar.gz
+  tar xf leptonica-1.69.tar.gz && rm -rf leptonica-1.69.tar.gz
+  cd leptonica-1.69
+  ./configure
+  make && checkinstall --pkgname=libleptonica --pkgversion="1.69" --backup=no --deldoc=yes --fstrans=no --default
+  cd ~/tesseract
+  wget https://github.com/tesseract-ocr/tesseract/archive/3.02.02.tar.gz
+  tar xf 3.02.02.tar.gz && rm -rf 3.02.02.tar.gz
+  cd tesseract-3.02.02
+  ./autogen.sh
+  ./configure
+  make && checkinstall --pkgname=tesseract-ocr --pkgversion="3.02.02" --backup=no --deldoc=yes --fstrans=no --default && ldconfig
+  mkdir ~/tesseract/langs
+  cd ~/tesseract/langs
+  wget https://raw.githubusercontent.com/tesseract-ocr/tessdata/master/eng.traineddata
+  echo "Deploying English trained language file"
+  cp eng.traineddata /usr/local/share/tessdata/
+  cd ~ && rm -rf ~/tesseract
+fi
+# If this fails, then we are out of luck
+echo -e "\ntessceract output:"
+tesseract --version && tesseract --list-langs

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -3,8 +3,15 @@ apt-get -y update
 apt-get -y install build-essential checkinstall 
 # Go for Ubuntu's packages first
 FROMSOURCE=0
-echo "Installing Tesseract OCR using Trusty Ubuntu Packages"
-apt-get -y install tesseract-ocr tesseract-ocr-eng
+KERNEL=$(uname -r) # kernel release version, e.g., "3.13.0-67-generic"
+VER="${KERNEL%.*-*}" # remove suffix starting with '.' and containing '-'
+VER="${KERNEL//.}" # remove periods
+#UBUNTU 14.04 has 3.13.x wich means VER == 313
+
+if [ "$VER" -ge 313 ]; then
+  echo "Installing Tesseract OCR using Trusty Ubuntu Packages"
+  apt-get -y install tesseract-ocr tesseract-ocr-eng
+fi
 # Check if install worked
 $(command -v tesseract --version > /dev/null 2>&1)
 if [ "$?" -eq "1" ]; then
@@ -15,6 +22,7 @@ if [ "$?" -eq "1" ]; then
   FROMSOURCE=1
 fi
 if [ "$FROMSOURCE" -eq 1 ]; then
+  echo "Installing Tesseract OCR from Source"
   mkdir ~/tesseract
   cd ~/tesseract
   wget http://www.leptonica.org/source/leptonica-1.69.tar.gz

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-apt-get update
-apt-get install build-essential checkinstall 
+apt-get -y update
+apt-get -y install build-essential checkinstall 
 # Go for Ubuntu's packages first
 FROMSOURCE=0
 echo "Installing Tesseract OCR using Trusty Ubuntu Packages"
@@ -10,7 +10,7 @@ $(command -v tesseract --version > /dev/null 2>&1)
 if [ "$?" -eq "1" ]; then
   printf "\n"
   echo "Tesseract could not be installed via apt-get"
-  printf "\n"
+  printf "\n"9082
   echo "Will try from source now"
   FROMSOURCE=1
 fi

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -3,11 +3,11 @@ apt-get --yes --force-yes update
 apt-get --yes --force-yes install build-essential checkinstall
 # Go for Ubuntu's packages first
 FROMSOURCE=0
-PRECISEDIST="`cat /etc/issue | grep 12.0 | wc -l`" # 1 for 12.0x ubuntu 
+UBUNTUDIST="`lsb_release -sc`" # "precise" means from source
 
-if [ "$PRECISEDIST" -ne 1 ]; then
+if [ "$UBUNTUDIST" != "precise" ]; then
   echo "Installing Tesseract OCR using Ubuntu Packages"
-  apt-get --yes --force-yes install tesseract-ocr tesseract-ocr-eng
+  apt-get --yes install tesseract-ocr tesseract-ocr-eng
 fi
 # Check if install worked or already there
 $(command -v tesseract --version > /dev/null 2>&1)

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -3,17 +3,13 @@ apt-get --yes --force-yes update
 apt-get --yes --force-yes install build-essential checkinstall
 # Go for Ubuntu's packages first
 FROMSOURCE=0
-KERNEL=$(uname -r) # kernel release version, e.g., "3.13.0-67-generic"
-VER="${KERNEL%.*-*}" # remove suffix starting with '.' and containing '-'
-VER=$(echo "$VER" | sed 's/\.//g') # remove periods
+PRECISEDIST="`cat /etc/issue | grep 12.0 | wc -l`" # 1 for 12.0x ubuntu 
 
-#UBUNTU 14.04 has 3.13.x wich means VER == 313
-
-if [ "$VER" -ge 313 ]; then
-  echo "Installing Tesseract OCR using Trusty Ubuntu Packages"
+if [ "$PRECISEDIST" -ne 1 ]; then
+  echo "Installing Tesseract OCR using Ubuntu Packages"
   apt-get --yes --force-yes install tesseract-ocr tesseract-ocr-eng
 fi
-# Check if install worked
+# Check if install worked or already there
 $(command -v tesseract --version > /dev/null 2>&1)
 if [ "$?" -eq "1" ]; then
   printf "\n"

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -14,7 +14,6 @@ if [ "$?" -eq "1" ]; then
   echo "Will try from source now"
   FROMSOURCE=1
 fi
-
 if [ "$FROMSOURCE" -eq 1 ]; then
   mkdir ~/tesseract
   cd ~/tesseract
@@ -38,5 +37,6 @@ if [ "$FROMSOURCE" -eq 1 ]; then
   cd ~ && rm -rf ~/tesseract
 fi
 # If this fails, then we are out of luck
-echo -e "\ntessceract output:"
+printf "\n"
+echo "tessceract output:"
 tesseract --version && tesseract --list-langs

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -1,27 +1,25 @@
 #!/bin/sh
 apt-get --yes --force-yes update
-apt-get --yes --force-yes install build-essential checkinstall
+apt-get --yes --force-yes install build-essential checkinstall automake libtool
 # Go for Ubuntu's packages first
-FROMSOURCE=0
-UBUNTUDIST="`lsb_release -sc`" # "precise" means from source
-
+UBUNTUDIST="`lsb_release -sc`" # precise means from source
+CANRUN="1"
 if [ "$UBUNTUDIST" != "precise" ]; then
   echo "Installing Tesseract OCR using Ubuntu Packages"
   apt-get --yes install tesseract-ocr tesseract-ocr-eng
 fi
-# Check if install worked or already there
-$(command -v tesseract --version > /dev/null 2>&1)
-if [ "$?" -eq "1" ]; then
+# Check if installation worked or was already there
+$(command -v tesseract --version >/dev/null 2>&1 || exit 1)
+CANRUN="$?"
+if [ "$CANRUN" -eq "1" ]; then
   printf "\n"
   echo "Tesseract could not be installed via apt-get"
   printf "\n"
   echo "Will try from source now"
-  FROMSOURCE=1
-fi
-if [ "$FROMSOURCE" -eq 1 ]; then
-  echo "Installing Tesseract OCR from Source"
   mkdir ~/tesseract
   cd ~/tesseract
+  printf "\n"
+  echo "Installing Tesseract OCR from Source"
   wget http://www.leptonica.org/source/leptonica-1.69.tar.gz
   tar xf leptonica-1.69.tar.gz && rm -rf leptonica-1.69.tar.gz
   cd leptonica-1.69

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -1,16 +1,17 @@
 #!/bin/sh
-apt-get -y update
-apt-get -y install build-essential checkinstall 
+apt-get --yes --force-yes update
+apt-get --yes --force-yes install build-essential checkinstall
 # Go for Ubuntu's packages first
 FROMSOURCE=0
 KERNEL=$(uname -r) # kernel release version, e.g., "3.13.0-67-generic"
 VER="${KERNEL%.*-*}" # remove suffix starting with '.' and containing '-'
-VER="${KERNEL//.}" # remove periods
+VER=$(echo "$VER" | sed 's/\.//g') # remove periods
+
 #UBUNTU 14.04 has 3.13.x wich means VER == 313
 
 if [ "$VER" -ge 313 ]; then
   echo "Installing Tesseract OCR using Trusty Ubuntu Packages"
-  apt-get -y install tesseract-ocr tesseract-ocr-eng
+  apt-get --yes --force-yes install tesseract-ocr tesseract-ocr-eng
 fi
 # Check if install worked
 $(command -v tesseract --version > /dev/null 2>&1)

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -10,7 +10,7 @@ $(command -v tesseract --version > /dev/null 2>&1)
 if [ "$?" -eq "1" ]; then
   printf "\n"
   echo "Tesseract could not be installed via apt-get"
-  printf "\n"9082
+  printf "\n"
   echo "Will try from source now"
   FROMSOURCE=1
 fi


### PR DESCRIPTION
JIRA TICKET: https://jira.duraspace.org/browse/ISLANDORA-1802
# What does this Pull Request do?

Travis is not passing, so this pull request solves that by changing the download location of tesseract(it's failing there!), used by our tests scripts, from google code (not existing) to github.com(existing)
# What's new?

Also adds a little more logic to the download and install process in case apt-get fails, falling back to source (from the correct source) in that case and only downloading the needed english learned data file instead of everything (cube, etc)
# How should this be tested?

Funny enough this should be self-testing, means if Travis passes the fix worked but some sanity check could also be helpful
# Additional Notes:

I kept Tesseract versions low, means we are not using the current ones. Since the tests do work with 3.02.02 i did not wanted to mess with that. the apt-get version is 3.03, if that fails it will compile 3.02
# Interested parties

@Islandora/7-x-1-x-committers or @dannylamb since this is a for-release-needed-pull
