### PR TITLE
Update Tesseract in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,6 @@ script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_solution_pack_newspaper
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_newspaper
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_solution_pack_newspaper
-  - sudo -u www-data php scripts/run-tests.sh --url http://localhost:8081 --verbose --class IslandoraNewspaperPageIngestTestCase
+  - drush test-run --uri=http://localhost:8081 "Islandora Newspaper"
 notifications:
   irc: "irc.freenode.org#islandora"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,6 @@ script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_solution_pack_newspaper
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_newspaper
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_solution_pack_newspaper
-  - drush test-run --uri=http://localhost:8081 "Islandora Newspaper"
+  - sudo -u www-data php scripts/run-tests.sh --url http://localhost:8081 --verbose --class IslandoraNewspaperPageIngestTestCase
 notifications:
   irc: "irc.freenode.org#islandora"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,6 @@ script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_solution_pack_newspaper
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_newspaper
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_solution_pack_newspaper
-  - drush test-run --uri=http://localhost:8081 "Islandora Newspaper"
+  - php scripts/run-tests.sh --php `phpenv which php` --url http://localhost:8081 --verbose --class IslandoraNewspaperPageIngestTestCase
 notifications:
   irc: "irc.freenode.org#islandora"

--- a/tests/islandora_newspaper_derivatives_ingest_purge.test
+++ b/tests/islandora_newspaper_derivatives_ingest_purge.test
@@ -95,7 +95,9 @@ class IslandoraNewspaperPageIngestTestCase extends IslandoraCollectionWebTestCas
       'titleInfo[title]' => $issue_title,
       'originInfo[dateIssued]' => '2002-02-20',
     );
-    $this->drupalPost($path, $edit, 'Ingest');
+    $this->drupalPost($path, $edit, t('Next'));
+    $this->assertText('PDF File', 'Optional PDF ingest step', 'Islandora');
+    $this->drupalPost(NULL, array(), t('Ingest'));
     $this->assertText($issue_title, 'Issue was created', 'Islandora');
 
     // Checks for issue datastream creation.
@@ -143,8 +145,5 @@ class IslandoraNewspaperPageIngestTestCase extends IslandoraCollectionWebTestCas
       array('JPG', 'image'),
     );
     $this->validateDatastreams($page_pid, $datastreams);
-
-    $this->deleteObject($newspaper_pid, 'Delete Newspaper');
-    $this->deleteTestCollection($collection_pid);
   }
 }

--- a/tests/islandora_newspaper_derivatives_ingest_purge.test
+++ b/tests/islandora_newspaper_derivatives_ingest_purge.test
@@ -95,7 +95,7 @@ class IslandoraNewspaperPageIngestTestCase extends IslandoraCollectionWebTestCas
       'titleInfo[title]' => $issue_title,
       'originInfo[dateIssued]' => '2002-02-20',
     );
-   
+
     $this->drupalPost($path, $edit, t('Ingest'));
     $this->assertText($issue_title, 'Issue was created', 'Islandora');
 

--- a/tests/islandora_newspaper_derivatives_ingest_purge.test
+++ b/tests/islandora_newspaper_derivatives_ingest_purge.test
@@ -95,9 +95,8 @@ class IslandoraNewspaperPageIngestTestCase extends IslandoraCollectionWebTestCas
       'titleInfo[title]' => $issue_title,
       'originInfo[dateIssued]' => '2002-02-20',
     );
-    $this->drupalPost($path, $edit, t('Next'));
-    $this->assertText('PDF File', 'Optional PDF ingest step', 'Islandora');
-    $this->drupalPost(NULL, array(), t('Ingest'));
+   
+    $this->drupalPost($path, $edit, t('Ingest'));
     $this->assertText($issue_title, 'Issue was created', 'Islandora');
 
     // Checks for issue datastream creation.

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -6,7 +6,7 @@ UBUNTUDIST="`lsb_release -sc`" # precise means from source
 CANRUN="1"
 if [ "$UBUNTUDIST" != "precise" ]; then
   echo "Installing Tesseract OCR using Ubuntu Packages"
-  apt-get --yes install tesseract-ocr tesseract-ocr-eng 
+  apt-get --yes install tesseract-ocr tesseract-ocr-eng
 fi
 # Check if installation worked or was already there
 $(command -v tesseract --version >/dev/null 2>&1 || exit 1)
@@ -33,7 +33,8 @@ if [ "$CANRUN" -eq "1" ]; then
   make && checkinstall --pkgname=tesseract-ocr --pkgversion="3.04.02b" --backup=no --deldoc=yes --fstrans=no --default && ldconfig
   mkdir ~/tesseract/langs
   cd ~/tesseract/langs
-  wget https://raw.githubusercontent.com/tesseract-ocr/tessdata/master/eng.traineddata
+  # tested also with https://github.com/tesseract-ocr/tessdata/releases/tag/3.04
+  wget https://raw.githubusercontent.com/tesseract-ocr/tessdata/4.00/eng.traineddata
   echo "Deploying English trained language file"
   cp eng.traineddata /usr/local/share/tessdata/
   cd ~ && rm -rf ~/tesseract

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -26,11 +26,11 @@ if [ "$CANRUN" -eq "1" ]; then
   ./configure
   make && checkinstall --pkgname=libleptonica --pkgversion="1.73" --backup=no --deldoc=yes --fstrans=no --default
   cd ~/tesseract
-  git clone https://github.com/tesseract-ocr/tesseract.git -b 3.04 3.04.01 --depth 1
-  cd 3.04.01
+  git clone https://github.com/tesseract-ocr/tesseract.git -b 3.04 3.04.02b --depth 1
+  cd 3.04.02b
   ./autogen.sh
   ./configure
-  make && checkinstall --pkgname=tesseract-ocr --pkgversion="3.04.01" --backup=no --deldoc=yes --fstrans=no --default && ldconfig
+  make && checkinstall --pkgname=tesseract-ocr --pkgversion="3.04.02b" --backup=no --deldoc=yes --fstrans=no --default && ldconfig
   mkdir ~/tesseract/langs
   cd ~/tesseract/langs
   wget https://raw.githubusercontent.com/tesseract-ocr/tessdata/master/eng.traineddata

--- a/tests/scripts/tesseract.sh
+++ b/tests/scripts/tesseract.sh
@@ -6,7 +6,7 @@ UBUNTUDIST="`lsb_release -sc`" # precise means from source
 CANRUN="1"
 if [ "$UBUNTUDIST" != "precise" ]; then
   echo "Installing Tesseract OCR using Ubuntu Packages"
-  apt-get --yes install tesseract-ocr tesseract-ocr-eng
+  apt-get --yes install tesseract-ocr tesseract-ocr-eng 
 fi
 # Check if installation worked or was already there
 $(command -v tesseract --version >/dev/null 2>&1 || exit 1)
@@ -20,18 +20,17 @@ if [ "$CANRUN" -eq "1" ]; then
   cd ~/tesseract
   printf "\n"
   echo "Installing Tesseract OCR from Source"
-  wget http://www.leptonica.org/source/leptonica-1.69.tar.gz
-  tar xf leptonica-1.69.tar.gz && rm -rf leptonica-1.69.tar.gz
-  cd leptonica-1.69
+  wget http://www.leptonica.org/source/leptonica-1.73.tar.gz
+  tar xf leptonica-1.73.tar.gz && rm -rf leptonica-1.73.tar.gz
+  cd leptonica-1.73
   ./configure
-  make && checkinstall --pkgname=libleptonica --pkgversion="1.69" --backup=no --deldoc=yes --fstrans=no --default
+  make && checkinstall --pkgname=libleptonica --pkgversion="1.73" --backup=no --deldoc=yes --fstrans=no --default
   cd ~/tesseract
-  wget https://github.com/tesseract-ocr/tesseract/archive/3.02.02.tar.gz
-  tar xf 3.02.02.tar.gz && rm -rf 3.02.02.tar.gz
-  cd tesseract-3.02.02
+  git clone https://github.com/tesseract-ocr/tesseract.git -b 3.04 3.04.01 --depth 1
+  cd 3.04.01
   ./autogen.sh
   ./configure
-  make && checkinstall --pkgname=tesseract-ocr --pkgversion="3.02.02" --backup=no --deldoc=yes --fstrans=no --default && ldconfig
+  make && checkinstall --pkgname=tesseract-ocr --pkgversion="3.04.01" --backup=no --deldoc=yes --fstrans=no --default && ldconfig
   mkdir ~/tesseract/langs
   cd ~/tesseract/langs
   wget https://raw.githubusercontent.com/tesseract-ocr/tessdata/master/eng.traineddata
@@ -41,5 +40,5 @@ if [ "$CANRUN" -eq "1" ]; then
 fi
 # If this fails, then we are out of luck
 printf "\n"
-echo "tessceract output:"
+echo "tesseract output:"
 tesseract --version && tesseract --list-langs


### PR DESCRIPTION
**JIRA Ticket:**

https://jira.duraspace.org/browse/ISLANDORA-1876

# What does this Pull Request do?

Fixes failing tesseract during Travis checks. It fails because the trained language files in github(master) are not longer compatible with the old Tesseract version we are downloading.

# What's new?

no black smoke and no fire (theory), could take a few iterations since i tested this locally on Ubuntu mandolin (12.04) but travis specs are a bit different. I could be missing some tiff, png, etc libraries

# Interested parties

@dannylamb @jonathangreen 