### PR TITLE
Replaces simplexml with dom.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -318,10 +318,8 @@ function islandora_newspaper_set_mods_date_issued(AbstractDatastream $datastream
     // origin info and is not specified as a point, additional logic could be
     // added to process different encodings.
     $dates = $xpath->query('//ns:mods/ns:originInfo/ns:dateIssued[not(@point)]');
-    if ($dates->length > 0) {
-      foreach ($dates as $d) {
-        $d->parentNode->removeChild($d);
-      }
+    foreach ($dates as $d) {
+      $d->parentNode->removeChild($d);
     }
     $new_date = $dom->createElementNS($dom->firstChild->namespaceURI, 'dateIssued', $date->format("Y-m-d"));
     $new_date->setAttribute('encoding', 'iso8601');

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -177,20 +177,20 @@ function islandora_newspaper_group_issues(array $issues) {
  */
 function islandora_newspaper_get_date_issued_from_mods(AbstractDatastream $datastream) {
   $out = FALSE;
-  $file = file_create_filename("{$datastream->parent->id}_{$datastream->id}.xml", 'temporary://');
-  $datastream->getContent($file);
-  @$doc = simplexml_load_file($file);
-  if ($doc) {
-    $doc->registerXPathNamespace('ns', 'http://www.loc.gov/mods/v3');
+  $dom = new DOMDocument();
+  $dom->loadXML($datastream->content);
+  $xpath = new DomXPath($dom);
+  if ($dom) {
+    $xpath->registerNamespace('ns', 'http://www.loc.gov/mods/v3');
     // Assumes the canonical date issued exists in the first mods document under
     // origin info and is not specified as a point, additional logic could be
     // added to process different encodings.
-    $dates = $doc->xpath('//ns:mods[1]/ns:originInfo/ns:dateIssued[not(@point)][1]');
-    $result = (string) reset($dates);
+    $dates = $xpath->query('//ns:mods/ns:originInfo/ns:dateIssued[not(@point)]')->item(0);
     try {
-      if (empty($result)) {
+      if (empty($dates)) {
         throw new Exception('mods:dateIssued element was empty.');
       }
+      $result = $dates->nodeValue;
       $out = new DateTime($result);
     }
     catch (Exception $e) {
@@ -199,7 +199,6 @@ function islandora_newspaper_get_date_issued_from_mods(AbstractDatastream $datas
       watchdog_exception('islandora_newspaper', $e, $msg, $vars, WATCHDOG_ERROR);
     }
   }
-  file_unmanaged_delete($file);
   return $out;
 }
 
@@ -310,17 +309,16 @@ EOQ;
  */
 function islandora_newspaper_set_mods_date_issued(AbstractDatastream $datastream, DateTime $date) {
   $out = FALSE;
-  $file = file_create_filename("{$datastream->parent->id}_{$datastream->id}.xml", 'temporary://');
-  $datastream->getContent($file);
-  @$doc = simplexml_load_file($file);
-  if ($doc) {
-    $doc->registerXPathNamespace('ns', 'http://www.loc.gov/mods/v3');
+  $dom = new DOMDocument();
+  $dom->loadXML($datastream->content);
+  $xpath = new DomXPath($dom);
+  if ($dom) {
+    $xpath->registerNamespace('ns', 'http://www.loc.gov/mods/v3');
     // Assumes the canonical date issued exists in the first mods document under
     // origin info and is not specified as a point, additional logic could be
     // added to process different encodings.
-    $parent = FALSE;
-    $dates = $doc->xpath('//ns:mods[1]/ns:originInfo/ns:dateIssued[not(@point)][1]');
-    if (is_array($dates) && count($dates) > 0) {
+    $dates = $xpath->query('//ns:mods/ns:originInfo/ns:dateIssued[not(@point)]');
+    if ($dates->length > 0) {
       $removal = array();
       // XX: Because you can't remove elements in a foreach loop
       // we collect them. Then we can add the new one and remove
@@ -329,32 +327,28 @@ function islandora_newspaper_set_mods_date_issued(AbstractDatastream $datastream
         $removal[] = $d;
       }
       foreach ($removal as $r) {
-        $dom = dom_import_simplexml($r);
-        $dom->parentNode->removeChild($dom);
+        $r->parentNode->removeChild($r);
       }
     }
-    $origin = $doc->xpath('//ns:mods[1]/ns:originInfo');
-    if ($origin) {
-      $parent = reset($origin);
+    $mods = $xpath->query('//ns:mods')->item(0);
+    $prefix = ($mods->prefix) ? ($mods->prefix) . ':' : '';
+    $new_date = $dom->createElement($prefix . 'dateIssued', $date->format("Y-m-d"));
+    $new_date->setAttribute('encoding', 'iso8601');
+    $origin = $xpath->query('ns:originInfo', $mods)->item(0);
+    if (!$origin) {
+      $origin = $dom->createElement($prefix . 'originInfo');
+      $origin = $mods->appendChild($origin);
     }
-    if ($parent) {
-      $new_date = $parent->addChild('dateIssued', $date->format("Y-m-d"), 'http://www.loc.gov/mods/v3');
-      $new_date->addAttribute('encoding', 'iso8601');
-      try {
-        $datastream->setContentFromString($doc->asXML());
-        $out = TRUE;
-      }
-      catch (Exception $e) {
-        $msg  = 'Failed to get save MODS datastream for @pid';
-        $vars = array('@pid' => $datastream->parent->id);
-        watchdog_exception('islandora_newspaper', $e, $msg, $vars, WATCHDOG_ERROR);
-      }
+    $new_date = $origin->appendChild($new_date);
+    try {
+      $datastream->setContentFromString($dom->saveXML());
+      $out = TRUE;
     }
-    else {
+    catch (Exception $e) {
+      $msg  = 'Failed to get save MODS datastream for @pid';
       $vars = array('@pid' => $datastream->parent->id);
-      watchdog('islandora_newspaper', 'Failed to get originInfo from MODS for @pid', $vars, WATCHDOG_ERROR);
+      watchdog_exception('islandora_newspaper', $e, $msg, $vars, WATCHDOG_ERROR);
     }
   }
-  file_unmanaged_delete($file);
   return $out;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -319,25 +319,16 @@ function islandora_newspaper_set_mods_date_issued(AbstractDatastream $datastream
     // added to process different encodings.
     $dates = $xpath->query('//ns:mods/ns:originInfo/ns:dateIssued[not(@point)]');
     if ($dates->length > 0) {
-      $removal = array();
-      // XX: Because you can't remove elements in a foreach loop
-      // we collect them. Then we can add the new one and remove
-      // the old.
       foreach ($dates as $d) {
-        $removal[] = $d;
-      }
-      foreach ($removal as $r) {
-        $r->parentNode->removeChild($r);
+        $d->parentNode->removeChild($d);
       }
     }
-    $mods = $xpath->query('//ns:mods')->item(0);
-    $prefix = ($mods->prefix) ? ($mods->prefix) . ':' : '';
-    $new_date = $dom->createElement($prefix . 'dateIssued', $date->format("Y-m-d"));
+    $new_date = $dom->createElementNS($dom->firstChild->namespaceURI, 'dateIssued', $date->format("Y-m-d"));
     $new_date->setAttribute('encoding', 'iso8601');
-    $origin = $xpath->query('ns:originInfo', $mods)->item(0);
+    $origin = $xpath->query('//ns:mods/ns:originInfo')->item(0);
     if (!$origin) {
-      $origin = $dom->createElement($prefix . 'originInfo');
-      $origin = $mods->appendChild($origin);
+      $origin = $dom->createElementNS($dom->firstChild->namespaceURI, 'originInfo');
+      $origin = $dom->firstChild->appendChild($origin);
     }
     $new_date = $origin->appendChild($new_date);
     try {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -178,9 +178,8 @@ function islandora_newspaper_group_issues(array $issues) {
 function islandora_newspaper_get_date_issued_from_mods(AbstractDatastream $datastream) {
   $out = FALSE;
   $dom = new DOMDocument();
-  $dom->loadXML($datastream->content);
-  $xpath = new DomXPath($dom);
-  if ($dom) {
+  if ($dom->loadXML($datastream->content)) {
+    $xpath = new DomXPath($dom);
     $xpath->registerNamespace('ns', 'http://www.loc.gov/mods/v3');
     // Assumes the canonical date issued exists in the first mods document under
     // origin info and is not specified as a point, additional logic could be
@@ -310,9 +309,8 @@ EOQ;
 function islandora_newspaper_set_mods_date_issued(AbstractDatastream $datastream, DateTime $date) {
   $out = FALSE;
   $dom = new DOMDocument();
-  $dom->loadXML($datastream->content);
-  $xpath = new DomXPath($dom);
-  if ($dom) {
+  if ($dom->loadXML($datastream->content)) {
+    $xpath = new DomXPath($dom);
     $xpath->registerNamespace('ns', 'http://www.loc.gov/mods/v3');
     // Assumes the canonical date issued exists in the first mods document under
     // origin info and is not specified as a point, additional logic could be


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2022](https://jira.duraspace.org/browse/ISLANDORA-2022)

# What does this Pull Request do?

This PR enables discrepancies in MODS info, specifically the dateIssued tag in Newspaper Issues, to be handled in a useful manner without getting confused by prefixes, or lack thereof.

# What's new?
It swaps out simplexml for dom.
When a MODS form doesn't have an originInfo tag, we now add one instead of crashing.

Example:
* If we do a Newspaper Batch ingest without MODS.xml files, or very sparse MODS.xml files, the module can add a date instead of crashing when entering a date in the your-newspaper/manage/newspaper.

# How should this be tested?

- A test batch with descriptions and expected behaviour is located in [ISLANDORA-2022](https://jira.duraspace.org/browse/ISLANDORA-2022)
- To reproduce the problem before testing this fix, create a Newspaper object, ingest an issue via Newspaper Batch without a MODS.xml file (you can extract issue2 from the test batch in the ticket), then try to enter a date in the manage/newspaper section of the paper containing that issue.

# Interested parties
@Islandora/7-x-1-x-committers
