### PR TITLE
Address ISLANDORA-2355; enable search term highlighting for issue obj…

### DIFF
--- a/islandora_newspaper.module
+++ b/islandora_newspaper.module
@@ -435,9 +435,7 @@ function islandora_newspaper_islandora_newspaperissuecmodel_islandora_solr_objec
       "2" => "2up",
       "3" => "thumb",
     );
-
     $ia_view = variable_get('islandora_internet_archive_bookreader_default_page_view', "1");
-
     $search_results['object_url_fragment'] = "page/1/mode/{$view_types[$ia_view]}/search/" . rawurlencode($query_processor->solrQuery);
   }
 }

--- a/islandora_newspaper.module
+++ b/islandora_newspaper.module
@@ -421,6 +421,28 @@ function islandora_newspaper_islandora_newspaperpagecmodel_islandora_solr_object
 }
 
 /**
+ * Implements hook_CMODEL_PID_islandora_solr_object_result_alter().
+ *
+ * Puts the Solr query terms into the object URL so that viewers can use them
+ * for highlighting.
+ */
+function islandora_newspaper_islandora_newspaperissuecmodel_islandora_solr_object_result_alter(&$search_results, $query_processor) {
+  module_load_include('inc', 'islandora', 'includes/solution_packs');
+  if (islandora_get_viewer_id('islandora_newspaper_issue_viewers') == 'islandora_internet_archive_bookreader' &&
+    ($query_processor->solrDefType == 'dismax' || $query_processor->solrDefType == 'edismax')) {
+    $view_types = array(
+      "1" => "1up",
+      "2" => "2up",
+      "3" => "thumb",
+    );
+
+    $ia_view = variable_get('islandora_internet_archive_bookreader_default_page_view', "1");
+
+    $search_results['object_url_fragment'] = "page/1/mode/{$view_types[$ia_view]}/search/" . rawurlencode($query_processor->solrQuery);
+  }
+}
+
+/**
  * Implements hook_process_theme().
  */
 function islandora_newspaper_preprocess_islandora_object_print(array &$variables) {


### PR DESCRIPTION
Enable search term highlighting for newspaper issue objects

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2355

# What does this Pull Request do?
It enables Solr search term highlighting in the IA viewer.


# What's new?
Add IA viewer required fragments to Solr result object url so IA viewer will highlight search terms in the HOCR

# How should this be tested?
Enable IA viewer for newspaper issue objects
Consolidate OCR on a newspaper issue object
Search for a term that exists in the above issue OCR
View issue object from search result; search term should be highlighted in IA viewer


# Additional Notes:
* Does this change require documentation to be updated?  No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# Interested parties
tagging @whikloj as maintainer
