### PR TITLE
Add namespace restriction

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -411,8 +411,15 @@ EOQ;
   // now we will just get XACML's directly.
   $query_optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'manage');
   $query_optionals[] = '?object islandora-rels-ext:dateIssued ?issued';
-  $query_filters = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_filters');
-  $query_filters = array_merge($query_filters, (array) module_invoke('islandora', 'islandora_basic_collection_get_query_filters'));
+
+  $filter_modules = array(
+    'islandora_xacml_api',
+    'islandora',
+  );
+  $query_filters = array();
+  foreach ($filter_modules as $module) {
+    $query_filters = array_merge_recursive($query_filters, (array) module_invoke($module, 'islandora_basic_collection_get_query_filters'));
+  }
   $query_filters[] = '!bound(?issued)';
 
   $filter_map = function ($filter) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -412,6 +412,7 @@ EOQ;
   $query_optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'manage');
   $query_optionals[] = '?object islandora-rels-ext:dateIssued ?issued';
   $query_filters = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_filters');
+  $query_filters = array_merge($query_filters, (array) module_invoke('islandora', 'islandora_basic_collection_get_query_filters'));
   $query_filters[] = '!bound(?issued)';
 
   $filter_map = function ($filter) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2488

# What does this Pull Request do?

Adds the islandora basic collection namespace SPARQL filter to the query used for selecting all newspaper issues missing a dateIssued.

# How should this be tested?

1. Create 2 newspapers in two different namespaces. Add one issue to each.
1. Then using the Admin tool (`http://localhost:8080/fedora/admin`) go to each issue and edit the RELS-EXT datastream, remove the `<islandora:dateIssued>XXXX</islandora:dateIssued>` element. **Save changes** before leaving each RELS-EXT.
1. Go to `http://localhost:8000/admin/islandora/solution_pack_config/newspaper/missing_dates`
1. See two entries, one for each issue in two different namespaces.
1. Go to `http://localhost:8000/admin/islandora/configure`
1. Choose the "Namespaces" tab, and check "Enforce namespace restrictions". Add **only** one of the namespaces to the "PID namespaces allowed in this Drupal install" box and **Save Configuration**.
1. Go back to `http://localhost:8000/admin/islandora/solution_pack_config/newspaper/missing_dates`
1. See both entries still there, but the text box for one will not be accessible.
1. Pull in this PR.
1. Reload the page and see the non-allowed namespaced object disappear.

# Interested parties
@Islandora/7-x-1-x-committers @bondjimbond 
