### PR TITLE
Legacy warning on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<img width="956" alt="Screen Shot 2021-08-11 at 1 20 55 PM" src="https://user-images.githubusercontent.com/2738244/129074556-76f3c3ca-e1b1-4e45-8da0-b07fc8ffdb35.png">
+This documentation covers the latest release of Islandora 7.x. For the very latest in Islandora, we recommend Islandora 8.
+
 # Newspaper Solution Pack [![Build Status](https://travis-ci.org/Islandora/islandora_solution_pack_newspaper.png?branch=7.x)](https://travis-ci.org/Islandora/islandora_solution_pack_newspaper)
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<img width="956" alt="Screen Shot 2021-08-11 at 1 20 55 PM" src="https://user-images.githubusercontent.com/2738244/129074556-76f3c3ca-e1b1-4e45-8da0-b07fc8ffdb35.png">
-This documentation covers the latest release of Islandora 7.x. For the very latest in Islandora, we recommend Islandora 8.
+[<img width="956" alt="Screen Shot 2021-08-11 at 1 20 55 PM" src="https://user-images.githubusercontent.com/2738244/129074556-76f3c3ca-e1b1-4e45-8da0-b07fc8ffdb35.png">](https://islandora.github.io/documentation/)
+This documentation covers the latest release of Islandora 7.x. For the very latest in Islandora, we recommend [Islandora 8](https://islandora.github.io/documentation/).
 
 # Newspaper Solution Pack [![Build Status](https://travis-ci.org/Islandora/islandora_solution_pack_newspaper.png?branch=7.x)](https://travis-ci.org/Islandora/islandora_solution_pack_newspaper)
 


### PR DESCRIPTION
Used an image to draw attention but included text for those using screen readers. Both the image and the text link to Islandora 8 docs.

**JIRA Ticket**: https://github.com/Islandora/documentation/issues/1885

# What does this Pull Request do?
Link to current version
Adds a very obvious image to attract people's attention that this is legacy software and they should look into a modern version.

<img width="1163" alt="Screen Shot 2021-09-27 at 4 29 34 PM" src="https://user-images.githubusercontent.com/2738244/134980647-34137402-e712-4fbc-89a2-a0b3ab4d2675.png">

# What's new?
Image/ info on where to go for Islandora 8

# How should this be tested?
N/A

# Additional Notes:
N/A

# Interested parties
@Islandora/7-x-1-x-committers
