### PR TITLE
Update theme.inc to fix the void error.

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -31,7 +31,7 @@ function template_preprocess_islandora_newspaper(array &$variables) {
       '#links' => array(
         array(
           'title' => t('Expand all months'),
-          'href' => "javascript://void(0)",
+          'href' => "#expand",
           'html' => TRUE,
           'external' => TRUE,
           'attributes' => array(
@@ -40,7 +40,7 @@ function template_preprocess_islandora_newspaper(array &$variables) {
         ),
         array(
           'title' => t('Collapse all months'),
-          'href' => "javascript://void(0)",
+          'href' => "#collapse",
           'html' => TRUE,
           'external' => TRUE,
           'attributes' => array(


### PR DESCRIPTION
# What does this Pull Request do?
Fixing the Void Error when viewing a newspaper collection

# What's new?

# How should this be tested?

* Clicking on "Expand all months" link currently opens a void site with an error. The URL that gets listed is https://void%280%29/.

![2022-09-20](https://user-images.githubusercontent.com/6493383/191375819-2680f27d-9d83-470b-bc81-46058c0c3c82.png)

* Apply this patch
* Try to click on "Expand all months" again. It should work as expected

# Additional Notes:
Here is only my quick suggested solution. Feel free to have better solution for this issue. For some reasons, Drupal is removing "javascript:" from the href attribute of the "Expand all months" link.

Example:
* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
