### PR TITLE
FIX: expand/collapse js 'void' error.

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -31,7 +31,7 @@ function template_preprocess_islandora_newspaper(array &$variables) {
       '#links' => array(
         array(
           'title' => t('Expand all months'),
-          'href' => "javascript://void(0)",
+          'href' => "javascript:void(0)",
           'html' => TRUE,
           'external' => TRUE,
           'attributes' => array(
@@ -40,7 +40,7 @@ function template_preprocess_islandora_newspaper(array &$variables) {
         ),
         array(
           'title' => t('Collapse all months'),
-          'href' => "javascript://void(0)",
+          'href' => "javascript:void(0)",
           'html' => TRUE,
           'external' => TRUE,
           'attributes' => array(


### PR DESCRIPTION
**JIRA Ticket**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
Added a comment on [this pull](https://github.com/Islandora/islandora_solution_pack_newspaper/pull/171), expanding on the solution.

# What does this Pull Request do?
Fix a js void error in expand/collapse functionality

# What's new?
Clicking expands or collapses when viewing the newspaper issue viewer should no longer link to the https://void%280%29 dummy page.

# How should this be tested?
With this pull request applied:
* Create a newspaper with multiple issues spanning multiple months
* Ensure issues have valid dates (to populate the issue viewer)
* Click 'Expand all months' and 'Collapse all months'
The intended result is that the hyperlinks no longer link to https://void%280%29, and expand/collapse the fieldsets as intended.

# Additional Notes:
Expanded on this a little further in [this comment](https://github.com/Islandora/islandora_solution_pack_newspaper/pull/171#issuecomment-1442398563).

# Interested parties
@Islandora/7-x-1-x-committers @simonhm
